### PR TITLE
Removed the override of root-font-size

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -5,7 +5,7 @@
 //$body-font-family: -apple-system, BlinkMacSystemFont, "helvetica neue", helvetica, roboto, noto, "segoe ui", arial, sans-serif;
 //$mono-font-family: "SFMono-Regular", Menlo, Consolas, Monospace;
 //$root-font-size: 16px; // Base font-size for rems
-$root-font-size: 18px;
+// $root-font-size: 18px;  //Changing this font size causes just-the-docs responsive styling to get buggy
 //$body-line-height: 1.4;
 //$content-line-height: 1.5;
 //$body-heading-line-height: 1.15;


### PR DESCRIPTION
When these sass style were implemented on the ExchangeLabOps page we noticed that it caused issue with responsive styling.  This fixed it for us.  (I opened an issue earlier today that this would resolve if you choose to keep it)